### PR TITLE
Set FCFLAGS as a target specific variable to prevent make from overwriting netcdf flags

### DIFF
--- a/ocean_only/Makefile
+++ b/ocean_only/Makefile
@@ -155,11 +155,10 @@ $(BUILD):
 
 
 # Dependencies
-
+$(FMS_BUILD)/libFMS.a: FCFLAGS := $(FMS_FCFLAGS)
 $(FMS_BUILD)/libFMS.a: $(wildcard $(FMS_CODEBASE)/*/*)
 	$(MAKE) -C ../shared/fms \
 	  BUILD=$(abspath $(FMS_BUILD)) \
-	  FCFLAGS="$(FMS_FCFLAGS)" \
 	  CODEBASE=$(abspath $(FMS_CODEBASE))
 
 FORCE:


### PR DESCRIPTION
Currently, when you try and build MOM and FMS at the same time, `FCFLAGS` gets overridden during the `FMS` build process to match the value of `FMS_FCFLAGS`. This means that even though the build process adds the netcdf libraries to `FCFLAGS` during the build process, these libraries aren't actually included in the  final `mpifort` command if you do not pass them to `FMS_FCFLAGS`. This is because `FCFLAGS` is currently being passed to the FMS submake as a "command line flag" (even though this isn't being run on the command line), which takes precedence over the `FCFLAGS` value that is set in the actual FMS makefile by the build process, which includes the correct netcdf library flags.

 This PR removes `FCFLAGS` from the the fms submake command and instead sets it as variable within that specific build process, which allows `make` to use the correct `FCFLAGS` put together by the build process instead of the value of `FMS_FCFLAGS` that you pass in. 